### PR TITLE
Set NPM release to public

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,5 +29,8 @@
     "@aws-quickstart/eks-blueprints": "latest",
     "source-map-support": "^0.5.16",
     "aws-cdk": "2.20.0"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }


### PR DESCRIPTION
Avoids paywall, and the release is public anyway.