### PR TITLE
Prevent GitHub Actions from attempting to release forks

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -26,7 +26,7 @@ jobs:
     name: Release
     needs: build
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: github.repository == 'snyk-partners/snyk-monitor-eks-blueprints-addon' && github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
     - uses: actions/checkout@v3
     - name: Configure Node.js 16


### PR DESCRIPTION
GitHub tried and failed (as expected) to release my fork:
https://github.com/schottsfired/ssp-eks-extension/actions/runs/2300935623

This PR should prevent that from happening in the future.